### PR TITLE
絵文字名の入力に大文字が含まれている場合小文字にならず_になる問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- fix: emoji name input was not converted to lowercase [`#91`](https://github.com/niri-la/MisskeyEmojiBot/pull/91)
 
 ### Removed
 

--- a/request-handler.go
+++ b/request-handler.go
@@ -270,10 +270,9 @@ func init() {
 			return response
 		}
 		reg := regexp.MustCompile(`[^a-z0-9_]+`)
-		result := reg.ReplaceAllStringFunc(m.Content, func(s string) string {
+		input := reg.ReplaceAllStringFunc(strings.ToLower(m.Content), func(s string) string {
 			return "_"
 		})
-		input := strings.ToLower(result)
 		s.ChannelMessageSend(m.ChannelID, ":: 入力されたメッセージ\n [ `"+input+"` ]")
 		s.ChannelMessageSend(m.ChannelID, ":---")
 		emoji.Name = input


### PR DESCRIPTION
fix: #88 
動作確認していません。
また、Goには詳しくないので一般的でない書き方ならすみません。